### PR TITLE
master以外でもビルドが通るか確認する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,36 +6,24 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/node:10.15
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
     working_directory: ~/repo
 
     steps:
       - checkout
 
-      # Download and cache dependencies
-      # - restore_cache:
-      #     keys:
-      #       - v1-dependencies-{{ checksum "package.json" }}
-      #       # fallback to using the latest cache if no exact match is found
-      #       - v1-dependencies-
-
       - run: npm install
-
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
       - run: cp -a functions/ dist/
       - run: yarn build:app
       - run: yarn export:app
+  deploy:
+    docker:
+      - image: circleci/node:10.15
+    working_directory: ~/repo
       - run: cp package.json dist/functions && cp package-lock.json dist/functions
       - run: mkdir pages
       - run: yarn firebase deploy --token=$FIREBASE_TOKEN
@@ -45,9 +33,11 @@ workflows:
   build-deploy:
     triggers:
     jobs:
-      - build:
+      - build
+      - deploy:
           filters:
             branches:
               only:
                 - master
-                - next9.1
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,13 @@ jobs:
       - run: cp -a functions/ dist/
       - run: yarn build:app
       - run: yarn export:app
-  deploy:
-    docker:
-      - image: circleci/node:10.15
-    working_directory: ~/repo
       - run: cp package.json dist/functions && cp package-lock.json dist/functions
       - run: mkdir pages
-      - run: yarn firebase deploy --token=$FIREBASE_TOKEN
+      - run:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ] || [ "${CIRCLE_BRANCH}" == "ci" ]; then
+              yarn firebase deploy --token=$FIREBASE_TOKEN
+            fi
 
 workflows:
   version: 2
@@ -34,10 +34,3 @@ workflows:
     triggers:
     jobs:
       - build
-      - deploy:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - build

--- a/app/containers/CircleEdit.tsx
+++ b/app/containers/CircleEdit.tsx
@@ -33,6 +33,7 @@ const CircleEdit: NextPage<{
         user={user}
         circle={circle}
         onSubmit={async circle => {
+          const db = firebase.firestore()
           const query = db.collection('circles').doc(id)
           await query.update(circle)
           router.push(`/${eventId}/mypage/circle`)


### PR DESCRIPTION
master以外ではビルドを行っていなかったが、マージしてからビルドが通らない場合もあった。
そのため、全ブランチでビルドが通るか確認し、master/ciブランチであれば加えてデプロイを行うようにした。

Next.jsに含まれる`fork-ts-checker-webpack-plugin`だけを単独で実行する方法があれば、もっとシンプルに書けそうな気がした。