### PR TITLE
chore: deploy from cloudbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 .next
-dist/
+dist/functions
 .firebase
 .firebaserc
 .envrc

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,3 +29,5 @@ steps:
         'managed',
         '--allow-unauthenticated',
       ]
+  - name: gcr.io/gishohaku/firebase
+    args: ['deploy', '--project=gishohaku', '--only=hosting']


### PR DESCRIPTION
Firebase Hostingのデプロイ設定が抜けていたのでCloud Buildにデプロイ処理を追加した。

以下のドキュメントを参考にした。

[Firebase へのデプロイ  |  Google Cloud](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase?hl=ja#yaml)