### PR TITLE
TOPのフッターリンクをgishohaku13に変更する

### DIFF
--- a/app/src/contexts/EventContext.tsx
+++ b/app/src/contexts/EventContext.tsx
@@ -8,7 +8,7 @@ export const getEventId = (router: NextRouter): EventId => {
   const pathname = router.asPath
   const [_, eventId] = pathname.split('/')
   if (eventId) return eventId as EventId
-  return 'gishohaku12'
+  return 'gishohaku13'
 }
 
 export const EventProvider: React.FC<{


### PR DESCRIPTION
TOPのフッターリンクが`gishohaku12`になっていたのを`gishohaku13`に変更しました。